### PR TITLE
Fix Mac compatibility for lint test

### DIFF
--- a/tests/lint.bats
+++ b/tests/lint.bats
@@ -13,8 +13,16 @@ if ! command -v shellcheck >/dev/null 2>&1; then
   exit 1
 fi
 
-mapfile -t scripts < <(grep -rlE '^#!.*\bbash' "${repo_root}" | grep -v "^${repo_root}/bin/" || true)
-mapfile -t bats_tests < <(find "${repo_root}/tests" -name '*.bats' -type f || true)
+scripts=()
+while IFS= read -r line; do
+  scripts+=("${line}")
+done < <(grep -rlE '^#!.*\bbash' "${repo_root}" | grep -v "^${repo_root}/bin/" || true)
+
+bats_tests=()
+while IFS= read -r line; do
+  bats_tests+=("${line}")
+done < <(find "${repo_root}/tests" -name '*.bats' -type f || true)
+
 scripts+=("${bats_tests[@]}")
 
 for script in "${scripts[@]}"; do


### PR DESCRIPTION
## Summary
- handle Bash versions without `mapfile` in `tests/lint.bats`

## Testing
- `./ci/test.sh`


------
https://chatgpt.com/codex/tasks/task_e_6860dbdb7d64832d9e4acecd05f6702b