### PR TITLE
Fix docker plugin loading in zsh

### DIFF
--- a/home/.zshrc
+++ b/home/.zshrc
@@ -14,7 +14,6 @@ if [[ ! -v ZSH_THEME ]]; then export ZSH_THEME="robbyrussell"; fi
 plugins=(
   $plugins
   brew
-  docker
   dotenv
   git
   git-auto-fetch
@@ -27,6 +26,11 @@ plugins=(
   terraform
   timer
 )
+
+# Load the docker plugin only if the docker command is available
+if command -v docker >/dev/null 2>&1; then
+  plugins+=(docker)
+fi
 
 source $ZSH/oh-my-zsh.sh
 


### PR DESCRIPTION
## Summary
- conditionally load the docker plugin
- run tests

## Testing
- `./ci/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_686190c01c20832d8b64fd9b791c5ce3