### PR TITLE
Add zsh linting support

### DIFF
--- a/home/.zshenv
+++ b/home/.zshenv
@@ -1,10 +1,11 @@
 #!/usr/bin/env zsh
+# shellcheck disable=SC1091
 
 # Source ~/.zshenv.local (not checked into the repo)
 # This is where you would put local configuration that's only for this computer.
 # For example, sourcing company specific files or setting secret keys as
 # environment variables.
-if [ -f "$HOME/.zshenv.local" ]; then source $HOME/.zshenv.local; fi
+if [[ -f "${HOME}/.zshenv.local" ]]; then source "${HOME}"/.zshenv.local; fi
 
 # Allow unlimited files to be opened at the same time.
 ulimit -u unlimited

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -1,10 +1,11 @@
 #!/usr/bin/env zsh
+# shellcheck disable=SC1091
 
 # Source ~/.zshrc.local (not checked into the repo)
 # This is where you would put local configuration that's only for this computer.
 # For example, sourcing company specific files or setting secret keys as
 # environment variables.
-if [ -f "$HOME/.zshrc.local" ]; then source $HOME/.zshrc.local; fi
+if [[ -f "${HOME}/.zshrc.local" ]]; then source "${HOME}"/.zshrc.local; fi
 
 # Path to your oh-my-zsh installation.
 export ZSH=~/.oh-my-zsh
@@ -14,7 +15,7 @@ if [[ ! -v ZSH_THEME ]]; then export ZSH_THEME="robbyrussell"; fi
 
 # zsh plugins
 plugins=(
-  $plugins
+  "${plugins[@]}"
   brew
   dotenv
   git
@@ -34,66 +35,87 @@ if command -v docker >/dev/null 2>&1; then
   plugins+=(docker)
 fi
 
-source $ZSH/oh-my-zsh.sh
+source "${ZSH}"/oh-my-zsh.sh
 
 # User configuration
 
 # Used by some programs (including hermit)
-export PATH=$HOME/bin:$PATH
+export PATH="${HOME}/bin:${PATH}"
 
 # Add homebrew shell environment
-if [ -f '/opt/homebrew/bin/brew' ]; then eval "$(/opt/homebrew/bin/brew shellenv)"; fi
+if [[ -f '/opt/homebrew/bin/brew' ]]; then
+  brew_env="$(/opt/homebrew/bin/brew shellenv)"
+  eval "${brew_env}"
+fi
 
-# Set vscode as default editor
-if [ -f '/usr/local/bin/code' ]; then export EDITOR="code -w"; fi
+# Set vscode as default editor if Code is available anywhere on PATH
+if command -v code >/dev/null 2>&1; then
+  export EDITOR="code -w"
+fi
 
 # Brew configuration
 export HOMEBREW_NO_ENV_HINTS=true
 
 # Git configuration
 zstyle ':completion:*:*:git:*' script ~/.zsh/git-completion.bash
-fpath=(~/.zsh $fpath)
+fpath=(~/.zsh "${fpath[@]}")
 
 # Docker specific configuration
 export DOCKER_ID_USER="matthewdolan"
-if [ -f "$HOME/.docker/init-zsh.sh" ]; then source "$HOME/.docker/init-zsh.sh"; fi # Added by Docker Desktop
+if [[ -f "${HOME}/.docker/init-zsh.sh" ]]; then source "${HOME}/.docker/init-zsh.sh"; fi # Added by Docker Desktop
 
 # Go specific configuration
 # Add $GOPATH/bin to path
-export GOPATH=$HOME/go
-if command -v go &>/dev/null ; then export PATH="$(go env GOPATH)/bin:$PATH" ; fi
+export GOPATH="${HOME}/go"
+if command -v go &>/dev/null; then
+  PATH="$(go env GOPATH)/bin:${PATH}"
+  export PATH
+fi
 
 # Ruby specific configuration
 # Add ruby gem home environment variable
-export GEM_HOME="$HOME/.gem"
-export PATH=$GEM_HOME/bin:$PATH
+export GEM_HOME="${HOME}/.gem"
+export PATH="${GEM_HOME}/bin:${PATH}"
 
 # Python specific configuration
 # Add python bin to the path
-if command -v python3 &>/dev/null ; then export PATH="$PATH:$(python3 -m site --user-base)/bin" ; fi
+if command -v python3 &>/dev/null; then
+  PATH="${PATH}:$(python3 -m site --user-base)/bin"
+  export PATH
+fi
 
 # Node specific configuration
-export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" # This loads nvm
-[ -s "$NVM_DIR/bash_completion" ] && . "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+export NVM_DIR="${HOME}/.nvm"
+[[ -s "${NVM_DIR}/nvm.sh" ]] && . "${NVM_DIR}/nvm.sh" # This loads nvm
+[[ -s "${NVM_DIR}/bash_completion" ]] && . "${NVM_DIR}/bash_completion"  # This loads nvm bash_completion
 
 # Kubernetes specific configuration
 # Set the kubernetes editor in addition to the base editor because for some reason it wasn't working
-if [ -f '/usr/local/bin/code' ]; then export KUBE_EDITOR="code --wait"; fi
+if command -v code >/dev/null 2>&1; then
+  export KUBE_EDITOR="code --wait"
+fi
 
 if [[ "${DOLAN_USE_GCLOUD:-false}" == "true" ]]; then
   # Google Cloud SDK specific configuration
   # The next line updates PATH for the Google Cloud SDK.
-  if [ -f "$HOME/Developer/google-cloud-sdk/path.zsh.inc" ]; then source "$HOME/Developer/google-cloud-sdk/path.zsh.inc"; fi
+  if [[ -f "${HOME}/Developer/google-cloud-sdk/path.zsh.inc" ]]; then
+    source "${HOME}/Developer/google-cloud-sdk/path.zsh.inc"
+  fi
   # The next line enables shell command completion for gcloud.
-  if [ -f "$HOME/Developer/google-cloud-sdk/completion.zsh.inc" ]; then source "$HOME/Developer/google-cloud-sdk/completion.zsh.inc"; fi
+  if [[ -f "${HOME}/Developer/google-cloud-sdk/completion.zsh.inc" ]]; then
+    source "${HOME}/Developer/google-cloud-sdk/completion.zsh.inc"
+  fi
 fi
 
 if [[ "${DOLAN_USE_HERMIT:-false}" == "true" ]]; then
   # Hermit Shell Hooks (https://github.com/cashapp/hermit)
   # If hermit hasn't been downloaded yet, `$HOME/bin/hermit shell-hooks --print --zsh` will print extraneous information about downloading it.
   # Calling `$HOME/bin/hermit version` first and sending the output to /dev/null will prevent this.
-  eval "$(test -x $HOME/bin/hermit &&  $HOME/bin/hermit version > /dev/null && $HOME/bin/hermit shell-hooks --print --zsh)"
+  if test -x "${HOME}"/bin/hermit; then
+    "${HOME}"/bin/hermit version > /dev/null
+    hermit_hooks="$("${HOME}"/bin/hermit shell-hooks --print --zsh)"
+    eval "${hermit_hooks}"
+  fi
 fi
 
 autoload -Uz compinit && compinit

--- a/tests/lint.bats
+++ b/tests/lint.bats
@@ -4,7 +4,13 @@ repo_root="$(git rev-parse --show-toplevel)"
 
 check_script() {
   local file="$1"
-  bash -n "${file}"
+  local shebang
+  shebang="$(head -n1 "${file}")"
+  if [[ "${shebang}" == *zsh* ]] && command -v zsh >/dev/null 2>&1; then
+    zsh -n "${file}"
+  else
+    bash -n "${file}"
+  fi
   shellcheck -x -s bash --severity=style --enable=all "${file}"
 }
 
@@ -16,7 +22,7 @@ fi
 scripts=()
 while IFS= read -r line; do
   scripts+=("${line}")
-done < <(grep -rlE '^#!.*\bbash' "${repo_root}" | grep -v "^${repo_root}/bin/" || true)
+done < <(grep -rlE '^#!.*\b(bash|zsh)' "${repo_root}" | grep -v "^${repo_root}/bin/" || true)
 
 bats_tests=()
 while IFS= read -r line; do


### PR DESCRIPTION
## Summary
- support linting zsh scripts in `lint.bats`
- quiet zshrc/zshenv shellcheck warnings
- detect `code` via `command -v`
- simplify zsh syntax checks in `lint.bats`

## Testing
- `./ci/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6861b9d8f650832da94666df1211233f